### PR TITLE
update Google analytic component

### DIFF
--- a/finalproject1/components/GoogleAnalytics.tsx
+++ b/finalproject1/components/GoogleAnalytics.tsx
@@ -12,8 +12,9 @@ export default function GoogleAnalytics({GA_MEASUREMENT_ID} : {GA_MEASUREMENT_ID
         const searchParams = useSearchParams()
     
         useEffect(() => {
-            const url = pathname + searchParams.toString()
-        
+                // Check if searchParams is not null before concatenating
+                const url = pathname + (searchParams ? searchParams.toString() : '');
+                        
             pageview(GA_MEASUREMENT_ID, url);
             
         }, [pathname, searchParams, GA_MEASUREMENT_ID]);


### PR DESCRIPTION
To resolve this error, you need to ensure that searchParams is not null before attempting to call .toString() on it. Here's a revised version of your code snippet that includes a null check:

~~~
useEffect(() => {
    // Check if searchParams is not null before concatenating
    const url = pathname + (searchParams ? searchParams.toString() : '');
    pageview(GA_MEASUREMENT_ID, url);
});

~~~
In this revised code, if searchParams is null, it simply appends an empty string, preventing any null reference errors. This is a common practice when dealing with values that may potentially be null or undefined in TypeScript or JavaScript.